### PR TITLE
Hotfix for playlist title and username

### DIFF
--- a/src/components/Main/Playlist/Playlist.jsx
+++ b/src/components/Main/Playlist/Playlist.jsx
@@ -107,6 +107,7 @@ class Playlist extends React.Component {
         <div className="container">
           <VideoPlayer
             playlistTitle={this.props.playlist.title}
+            playlistUsername={this.props.playlist.username}
             current={this.props.playlist.current}
             username={this.props.username}
             getRelatedVideos={this.props.getRelatedVideos}

--- a/src/components/Main/VideoPlayer/VideoPlayer.jsx
+++ b/src/components/Main/VideoPlayer/VideoPlayer.jsx
@@ -170,7 +170,7 @@ class VideoPlayer extends React.Component {
           </span>
           <span> created by </span>
           <span className="playlist_username">
-            {this.props.username}
+            {this.props.playlistUsername}
           </span>
         </div>
       </div>
@@ -180,6 +180,7 @@ class VideoPlayer extends React.Component {
 
 VideoPlayer.propTypes = {
   playlistTitle: PropTypes.string,
+  playlistUsername: PropTypes.string,
   deleteVideo: PropTypes.func.isRequired,
   finishVideo: PropTypes.func.isRequired,
   getRelatedVideos: PropTypes.func.isRequired,


### PR DESCRIPTION
The displayed username was from current user instead from the playlists owner.